### PR TITLE
Add Generic Input Config

### DIFF
--- a/epi-display-samsung-mdc/SamsungMdcCommands.cs
+++ b/epi-display-samsung-mdc/SamsungMdcCommands.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Crestron.SimplSharp;
-
-namespace PepperDashPluginSamsungMdcDisplay
+﻿namespace PepperDashPluginSamsungMdcDisplay
 {
     public class SamsungMdcCommands
     {
@@ -174,6 +168,11 @@ namespace PepperDashPluginSamsungMdcDisplay
         /// 2.1.14 Input source control - HDMI4 PC
         /// </summary>
         public const byte InputHdmi4Pc = 0x34;
+
+        /// <summary>
+        /// 2.1.14 Input source control - MagicInfo
+        /// </summary>
+        public const byte InputMagicInfo = 0x20;
 
         /// <summary>
         /// 2.1.14 Input source control - TV1
@@ -366,7 +365,7 @@ namespace PepperDashPluginSamsungMdcDisplay
 
         /// <summary>
         /// 2.1.D0.84 Led Monitoring (LED product feature sub cmd: 0x84)
-        /// Gets LED Product status, status includes: val1=Power&IC, val2=HDBaseT_Status, val3=Temperature, val4=Illuminance, val5=Module1, val6=Module1_LED_Error_Data,.... valN=ModuleX, valN+1=ModuleX_LED_Error_Data\
+        /// Gets LED Product status, status includes: val1=Power_IC, val2=HDBaseT_Status, val3=Temperature, val4=Illuminance, val5=Module1, val6=Module1_LED_Error_Data,.... valN=ModuleX, valN+1=ModuleX_LED_Error_Data\
         /// Temperature range 0C-254C
         /// Illuminance range 0d - 100d (0x00 - 0x64)
         /// </summary>

--- a/epi-display-samsung-mdc/SamsungMdcConfigObject.cs
+++ b/epi-display-samsung-mdc/SamsungMdcConfigObject.cs
@@ -3,38 +3,42 @@ using Newtonsoft.Json;
 
 namespace PepperDashPluginSamsungMdcDisplay
 {
-    public class SamsungMDCDisplayPropertiesConfig
+    public class SamsungMdcDisplayPropertiesConfig
     {
         [JsonProperty("id")]
         public string Id { get; set; }
 
         [JsonProperty("volumeUpperLimit")]
-        public int volumeUpperLimit { get; set; }
+        public int VolumeUpperLimit { get; set; }
 
         [JsonProperty("volumeLowerLimit")]
-        public int volumeLowerLimit { get; set; }
+        public int VolumeLowerLimit { get; set; }
 
         [JsonProperty("pollIntervalMs")]
-        public long pollIntervalMs { get; set; }
+        public long PollIntervalMs { get; set; }
 
         [JsonProperty("coolingTimeMs")]
-        public uint coolingTimeMs { get; set; }
+        public uint CoolingTimeMs { get; set; }
 
         [JsonProperty("warmingTimeMs")]
-        public uint warmingTimeMs { get; set; }
+        public uint WarmingTimeMs { get; set; }
 
         [JsonProperty("showVolumeControls")]
-        public bool showVolumeControls { get; set; }
+        public bool ShowVolumeControls { get; set; }
 
         [JsonProperty("pollLedTemps")]
-        public bool pollLedTemps { get; set; }
+        public bool PollLedTemps { get; set; }
 
         [JsonProperty("friendlyNames")]
         public List<FriendlyName> FriendlyNames { get; set; }
 
-        public SamsungMDCDisplayPropertiesConfig()
+        [JsonProperty("customInputs")]
+        public List<CustomInput> CustomInputs { get; set; } 
+
+        public SamsungMdcDisplayPropertiesConfig()
         {
             FriendlyNames = new List<FriendlyName>();
+            CustomInputs = new List<CustomInput>();
         }
     }
 
@@ -45,5 +49,15 @@ namespace PepperDashPluginSamsungMdcDisplay
 
         [JsonProperty("name")]
         public string Name { get; set; }
+    }
+
+    public class CustomInput
+    {
+        [JsonProperty("inputCommand")]
+        public string InputCommand { get; set; }
+        [JsonProperty("inputConnector")]
+        public string InputConnector { get; set; }
+        [JsonProperty("inputIdentifier")]
+        public string InputIdentifier { get; set; }
     }
 }

--- a/epi-display-samsung-mdc/SamsungMdcControllerFactory.cs
+++ b/epi-display-samsung-mdc/SamsungMdcControllerFactory.cs
@@ -2,7 +2,6 @@
 using PepperDash.Core;
 using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.Config;
-using PepperDashPluginSamsungMdcDisplay;
 
 namespace PepperDashPluginSamsungMdcDisplay
 {
@@ -27,7 +26,7 @@ namespace PepperDashPluginSamsungMdcDisplay
                 return null;
             }
 
-            var config = dc.Properties.ToObject<SamsungMDCDisplayPropertiesConfig>();
+            var config = dc.Properties.ToObject<SamsungMdcDisplayPropertiesConfig>();
 
             if (config != null)
             {


### PR DESCRIPTION
Gives the option to build the routing input ports from config.

Makes the joinmaps printable