### PR TITLE
fix: use CurrentInputPort from base class

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "ms-dotnettools.vscode-dotnet-runtime",
+    "ms-dotnettools.csharp",
+    "ms-dotnettools.csdevkit",
+    "vivaxy.vscode-conventional-commits",
+    "mhutchie.git-graph"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,32 @@
+{
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#fb8533",
+    "activityBar.background": "#fb8533",
+    "activityBar.foreground": "#15202b",
+    "activityBar.inactiveForeground": "#15202b99",
+    "activityBarBadge.background": "#a1fdc7",
+    "activityBarBadge.foreground": "#15202b",
+    "commandCenter.border": "#15202b99",
+    "sash.hoverBorder": "#fb8533",
+    "statusBar.background": "#f66805",
+    "statusBar.foreground": "#15202b",
+    "statusBarItem.hoverBackground": "#c45304",
+    "statusBarItem.remoteBackground": "#f66805",
+    "statusBarItem.remoteForeground": "#15202b",
+    "titleBar.activeBackground": "#f66805",
+    "titleBar.activeForeground": "#15202b",
+    "titleBar.inactiveBackground": "#f6680599",
+    "titleBar.inactiveForeground": "#15202b99"
+  },
+  "peacock.color": "#f66805",
+  "[csharp]": {
+    "editor.defaultFormatter": "ms-dotnettools.csharp",
+    "editor.formatOnSave": true,
+    "editor.formatOnSaveMode": "file"
+  },
+  "csharp.inlayHints.enableInlayHintsForImplicitObjectCreation": true,
+  "csharp.inlayHints.enableInlayHintsForImplicitVariableTypes": true,
+  "csharp.inlayHints.enableInlayHintsForLambdaParameterTypes": true,
+  "csharp.inlayHints.enableInlayHintsForTypes": true,
+  "dotnet.formatting.organizeImportsOnFormat": true,  
+}

--- a/src/SamsungMdcControllerFactory.cs
+++ b/src/SamsungMdcControllerFactory.cs
@@ -5,13 +5,13 @@ using PepperDash.Essentials.Core.Config;
 
 namespace PepperDashPluginSamsungMdcDisplay
 {
-    public class SamsungMdcControllerFactory:EssentialsPluginDeviceFactory<SamsungMdcDisplayController>
+    public class SamsungMdcControllerFactory : EssentialsPluginDeviceFactory<SamsungMdcDisplayController>
     {
         public SamsungMdcControllerFactory()
         {
             MinimumEssentialsFrameworkVersion = "2.4.7";
 
-            TypeNames = new List<string> {"samsungMdcPlugin"};
+            TypeNames = new List<string> { "samsungMdcPlugin" };
         }
 
         #region Overrides of EssentialsDeviceFactory<SamsungMdcDisplayController>
@@ -22,7 +22,7 @@ namespace PepperDashPluginSamsungMdcDisplay
 
             if (comms == null)
             {
-                Debug.Console(0, Debug.ErrorLogLevel.Error, "Unable to create comms for device {0}", dc.Key);
+                Debug.LogError("Unable to create comms for device {0}", dc.Key);
                 return null;
             }
 
@@ -33,7 +33,7 @@ namespace PepperDashPluginSamsungMdcDisplay
                 return new SamsungMdcDisplayController(dc.Key, dc.Name, config, comms);
             }
 
-            Debug.Console(0, Debug.ErrorLogLevel.Error, "Unable to deserialize config for device {0}", dc.Key);
+            Debug.LogError("Unable to deserialize config for device {0}", dc.Key);
             return null;
         }
 


### PR DESCRIPTION
This pull request introduces several improvements focused on enhancing logging practices, code maintainability, and developer experience for the Samsung MDC Display plugin. The most significant changes are the systematic replacement of legacy `Debug.Console` calls with the newer `LogDebug`, `LogVerbose`, and `LogError` extension methods, as well as the addition of recommended VSCode extensions and settings for a more consistent development environment.

**Logging and Debugging Enhancements:**

* Replaced all usages of `Debug.Console` and `Debug.LogError` with structured logging extension methods (`LogDebug`, `LogVerbose`, `LogError`) throughout `SamsungMdc.cs` for improved log clarity and maintainability. [[1]](diffhunk://#diff-f4068dd98484feda80771c9ec44f62a1fa5a40c0a3af84a76f90e603f2fe6c8aL86-R88) [[2]](diffhunk://#diff-f4068dd98484feda80771c9ec44f62a1fa5a40c0a3af84a76f90e603f2fe6c8aL100-L116) [[3]](diffhunk://#diff-f4068dd98484feda80771c9ec44f62a1fa5a40c0a3af84a76f90e603f2fe6c8aL267-R250) [[4]](diffhunk://#diff-f4068dd98484feda80771c9ec44f62a1fa5a40c0a3af84a76f90e603f2fe6c8aL294-R284) [[5]](diffhunk://#diff-f4068dd98484feda80771c9ec44f62a1fa5a40c0a3af84a76f90e603f2fe6c8aL317-R307) [[6]](diffhunk://#diff-f4068dd98484feda80771c9ec44f62a1fa5a40c0a3af84a76f90e603f2fe6c8aL446-R428) [[7]](diffhunk://#diff-f4068dd98484feda80771c9ec44f62a1fa5a40c0a3af84a76f90e603f2fe6c8aL473-R455) [[8]](diffhunk://#diff-f4068dd98484feda80771c9ec44f62a1fa5a40c0a3af84a76f90e603f2fe6c8aL484-R467) [[9]](diffhunk://#diff-f4068dd98484feda80771c9ec44f62a1fa5a40c0a3af84a76f90e603f2fe6c8aL495-R477) [[10]](diffhunk://#diff-f4068dd98484feda80771c9ec44f62a1fa5a40c0a3af84a76f90e603f2fe6c8aL521-R528) [[11]](diffhunk://#diff-f4068dd98484feda80771c9ec44f62a1fa5a40c0a3af84a76f90e603f2fe6c8aL574-R556) [[12]](diffhunk://#diff-f4068dd98484feda80771c9ec44f62a1fa5a40c0a3af84a76f90e603f2fe6c8aL631-R609) [[13]](diffhunk://#diff-f4068dd98484feda80771c9ec44f62a1fa5a40c0a3af84a76f90e603f2fe6c8aL674-R652) [[14]](diffhunk://#diff-f4068dd98484feda80771c9ec44f62a1fa5a40c0a3af84a76f90e603f2fe6c8aL771-R749) [[15]](diffhunk://#diff-f4068dd98484feda80771c9ec44f62a1fa5a40c0a3af84a76f90e603f2fe6c8aL780-R763)
* Updated exception handling to use the new logging methods for error and stack trace reporting.

**Code Quality and Refactoring:**

* Removed the unused `ListInputPorts` method and related debug output to clean up the codebase. [[1]](diffhunk://#diff-f4068dd98484feda80771c9ec44f62a1fa5a40c0a3af84a76f90e603f2fe6c8aL126-L140) [[2]](diffhunk://#diff-f4068dd98484feda80771c9ec44f62a1fa5a40c0a3af84a76f90e603f2fe6c8aL154-L155)
* Replaced explicit type checks and casts with C# pattern matching for improved readability and safety in type handling. [[1]](diffhunk://#diff-f4068dd98484feda80771c9ec44f62a1fa5a40c0a3af84a76f90e603f2fe6c8aL208-R198) [[2]](diffhunk://#diff-f4068dd98484feda80771c9ec44f62a1fa5a40c0a3af84a76f90e603f2fe6c8aL962-R940)
* Minor refactorings for clarity, such as using `CurrentInputPort` instead of a private field and removing redundant blank lines.

**Interface and Dependency Updates:**

* Added `IRoutingSinkWithSwitchingWithInputPort` to the class interface list, expanding the class's capabilities for routing scenarios.
* Added missing `using` directives for `PepperDash.Core.Logging` and `System.Diagnostics.Metrics` to support new logging methods and future metrics. [[1]](diffhunk://#diff-f4068dd98484feda80771c9ec44f62a1fa5a40c0a3af84a76f90e603f2fe6c8aR8) [[2]](diffhunk://#diff-f4068dd98484feda80771c9ec44f62a1fa5a40c0a3af84a76f90e603f2fe6c8aR17)

**Development Environment Improvements:**

* Added a `.vscode/extensions.json` file recommending essential VSCode extensions for C# development, conventional commits, and Git visualization.
* Added a `.vscode/settings.json` file with workspace color customizations, C# formatting, and inlay hint settings to standardize the development experience.