### PR TITLE
fix: prevent buffer overflow crash when TCP packet contains multiple MDC messages

### DIFF
--- a/src/SamsungMdc.cs
+++ b/src/SamsungMdc.cs
@@ -482,7 +482,7 @@ namespace PepperDashPluginSamsungMdcDisplay
                     if (newBytes.Length >= dataLength)
                     {
                         var message = new byte[dataLength];
-                        newBytes.CopyTo(message, 0);
+                        Array.Copy(newBytes, 0, message, 0, dataLength);
                         ParseMessage(message);
                         byte[] clear = { };
                         _incomingBuffer = clear;


### PR DESCRIPTION
## Summary

- `Communication_BytesReceived` crashes with `ArgumentException: Destination array was not long enough` when a volume command feedback response and the next poll response arrive in the same TCP packet
- `newBytes.CopyTo(message, 0)` copies the **entire** `newBytes` buffer into `message`, but `message` is sized to `dataLength` — when `newBytes.Length > dataLength` the copy throws
- Fix: replace with `Array.Copy(newBytes, 0, message, 0, dataLength)` to copy only the bytes belonging to the current message

## Root cause

```csharp
// Before (buggy)
var message = new byte[dataLength];
newBytes.CopyTo(message, 0);  // throws if newBytes.Length > dataLength

// After (fixed)
Array.Copy(newBytes, 0, message, 0, dataLength);
```

## Reproduction

Reliably reproduced by sending volume up/down commands rapidly — the display sends a volume feedback response followed immediately by the next poll response in the same TCP receive event, making `newBytes.Length > dataLength`.

## Test plan

- [ ] Send volume up/down commands repeatedly from a mobile control UI client
- [ ] Confirm no `Exception parsing feedback: Destination array was not long enough` errors in the processor log
- [ ] Confirm volume level and mute feedback continues to update correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)