### PR TITLE
fix: update callback Timers set themselves null

### DIFF
--- a/src/SamsungMdc.cs
+++ b/src/SamsungMdc.cs
@@ -516,72 +516,72 @@ namespace PepperDashPluginSamsungMdcDisplay
             {
                 // General status
                 case SamsungMdcCommands.StatusControl:
-                {
-                    //UpdatePowerFB(message[2], message[5]); // "power" can be misrepresented when the display sleeps
-                    // Handle the first power on fb when waiting for it.
-                    if (_isPoweringOnIgnorePowerFb && message[6] == SamsungMdcCommands.PowerOn)
                     {
-                        _isPoweringOnIgnorePowerFb = false;
+                        //UpdatePowerFB(message[2], message[5]); // "power" can be misrepresented when the display sleeps
+                        // Handle the first power on fb when waiting for it.
+                        if (_isPoweringOnIgnorePowerFb && message[6] == SamsungMdcCommands.PowerOn)
+                        {
+                            _isPoweringOnIgnorePowerFb = false;
+                        }
+                        // Ignore general-status power off messages when powering up
+                        // if (!(_isPoweringOnIgnorePowerFb && message[6] == PowerOff))
+                        UpdatePowerFb(message[6]);
+                        UpdateVolumeFb(message[7]);
+                        UpdateMuteFb(message[8]);
+                        UpdateInputFb(message[9]);
+                        if (Debug.Level == 2)
+                        {
+                            // This check is here to prevent following string format from building unnecessarily on level 0 or 1
+                            this.LogVerbose(
+                                "StatusControl Power-'{0}d', Input-'{1}d',  Volume-'{2}d', Mute-'{3}d'",
+                                message[6],
+                                message[9],
+                                message[7],
+                                message[8]
+                            );
+                        }
+                        break;
                     }
-                    // Ignore general-status power off messages when powering up
-                    // if (!(_isPoweringOnIgnorePowerFb && message[6] == PowerOff))
-                    UpdatePowerFb(message[6]);
-                    UpdateVolumeFb(message[7]);
-                    UpdateMuteFb(message[8]);
-                    UpdateInputFb(message[9]);
-                    if (Debug.Level == 2)
-                    {
-                        // This check is here to prevent following string format from building unnecessarily on level 0 or 1
-                        this.LogVerbose(
-                            "StatusControl Power-'{0}d', Input-'{1}d',  Volume-'{2}d', Mute-'{3}d'",
-                            message[6],
-                            message[9],
-                            message[7],
-                            message[8]
-                        );
-                    }
-                    break;
-                }
                 // Power status
                 case SamsungMdcCommands.PowerControl:
-                {
-                    this.LogVerbose("PowerControl-'{0}d'", message[6]);
-                    UpdatePowerFb(message[6]);
-                    break;
-                }
+                    {
+                        this.LogVerbose("PowerControl-'{0}d'", message[6]);
+                        UpdatePowerFb(message[6]);
+                        break;
+                    }
                 // Volume level
                 case SamsungMdcCommands.VolumeControl:
-                {
-                    if (message[6] != _lastVolumeFeedbackReceived)
                     {
-                        this.LogVerbose("VolumeControl-'{0}d'", message[6]);
-                        _lastVolumeFeedbackReceived = message[6];
+                        if (message[6] != _lastVolumeFeedbackReceived)
+                        {
+                            this.LogVerbose("VolumeControl-'{0}d'", message[6]);
+                            _lastVolumeFeedbackReceived = message[6];
+                        }
+                        UpdateVolumeFb(message[6]);
+                        break;
                     }
-                    UpdateVolumeFb(message[6]);
-                    break;
-                }
                 // Volume mute status
                 case SamsungMdcCommands.MuteControl:
-                {
-                    if (message[6] != _lastMuteFeedbackReceived)
                     {
-                        this.LogVerbose("MuteControl-'{0}d'", message[6]);
-                        _lastMuteFeedbackReceived = message[6];
+                        if (message[6] != _lastMuteFeedbackReceived)
+                        {
+                            this.LogVerbose("MuteControl-'{0}d'", message[6]);
+                            _lastMuteFeedbackReceived = message[6];
+                        }
+                        UpdateMuteFb(message[6]);
+                        break;
                     }
-                    UpdateMuteFb(message[6]);
-                    break;
-                }
                 // Input status
                 case SamsungMdcCommands.InputSourceControl:
-                {
-                    if (message[6] != _lastInputFeedbackReceived)
                     {
-                        this.LogVerbose("InputSourceControl-'{0}d'", message[6]);
-                        _lastInputFeedbackReceived = message[6];
+                        if (message[6] != _lastInputFeedbackReceived)
+                        {
+                            this.LogVerbose("InputSourceControl-'{0}d'", message[6]);
+                            _lastInputFeedbackReceived = message[6];
+                        }
+                        UpdateInputFb(message[6]);
+                        break;
                     }
-                    UpdateInputFb(message[6]);
-                    break;
-                }
                 // Monitoring (Sub CMD 0x84, 2.1.D0.84 Monitoring, pdf page 228 or 244)
                 // msg[0] = Header, 0xAA
                 // msg[1] = Command, 0xFF
@@ -601,75 +601,75 @@ namespace PepperDashPluginSamsungMdcDisplay
                 // msg[n] = val-n, moduleN
                 // msg[n+1] = val-n+1, moduleN LED error data
                 case SamsungMdcCommands.LedProductFeature:
-                {
-                    this.LogVerbose(
-                        "LedProductFeature SubCmd{0} DataLen{1}",
-                        message[6],
-                        message[3]
-                    );
-
-                    if (message[6] == SamsungMdcCommands.LedSubcmdMonitoring)
                     {
                         this.LogVerbose(
-                            "LedProductFeature SubCmd{0} Temperature{1}",
+                            "LedProductFeature SubCmd{0} DataLen{1}",
                             message[6],
-                            message[9]
+                            message[3]
                         );
-                        UpdateLedTemperatureFb(message[9]);
-                    }
-                    break;
-                }
-                // Serial number control
-                case SamsungMdcCommands.SerialNumberControl:
-                {
-                    var serialNumber = new byte[18];
-                    Array.Copy(message, 6, serialNumber, 0, 18);
 
-                    UpdateSerialNumber(serialNumber);
-                    break;
-                }
-                // Software version control
-                case SamsungMdcCommands.SwVersionControl:
-                {
-                    var length = message[3];
-
-                    var firmware = new byte[length];
-
-                    Array.Copy(message, 6, firmware, 0, length);
-
-                    UpdateFirmwareVersion(firmware);
-                    break;
-                }
-                // Network info
-                case SamsungMdcCommands.SystemConfiguration:
-                {
-                    var length = message[3];
-                    if (message[4] == SamsungMdcCommands.NetworkConfiguration)
-                    {
-                        var ipAddressInfo = new byte[length - 1];
-
-                        Array.Copy(message, 7, ipAddressInfo, 0, length - 1);
-
-                        UpdateNetworkInfo(ipAddressInfo);
+                        if (message[6] == SamsungMdcCommands.LedSubcmdMonitoring)
+                        {
+                            this.LogVerbose(
+                                "LedProductFeature SubCmd{0} Temperature{1}",
+                                message[6],
+                                message[9]
+                            );
+                            UpdateLedTemperatureFb(message[9]);
+                        }
                         break;
                     }
-
-                    if (message[4] == SamsungMdcCommands.SystemConfigurationMacAddress)
+                // Serial number control
+                case SamsungMdcCommands.SerialNumberControl:
                     {
-                        var macInfo = new byte[length - 1];
+                        var serialNumber = new byte[18];
+                        Array.Copy(message, 6, serialNumber, 0, 18);
 
-                        Array.Copy(message, 6, macInfo, 0, length - 1);
-
-                        UpdateMacAddress(macInfo);
+                        UpdateSerialNumber(serialNumber);
+                        break;
                     }
+                // Software version control
+                case SamsungMdcCommands.SwVersionControl:
+                    {
+                        var length = message[3];
 
-                    break;
-                }
+                        var firmware = new byte[length];
+
+                        Array.Copy(message, 6, firmware, 0, length);
+
+                        UpdateFirmwareVersion(firmware);
+                        break;
+                    }
+                // Network info
+                case SamsungMdcCommands.SystemConfiguration:
+                    {
+                        var length = message[3];
+                        if (message[4] == SamsungMdcCommands.NetworkConfiguration)
+                        {
+                            var ipAddressInfo = new byte[length - 1];
+
+                            Array.Copy(message, 7, ipAddressInfo, 0, length - 1);
+
+                            UpdateNetworkInfo(ipAddressInfo);
+                            break;
+                        }
+
+                        if (message[4] == SamsungMdcCommands.SystemConfigurationMacAddress)
+                        {
+                            var macInfo = new byte[length - 1];
+
+                            Array.Copy(message, 6, macInfo, 0, length - 1);
+
+                            UpdateMacAddress(macInfo);
+                        }
+
+                        break;
+                    }
                 default:
-                {
-                    this.LogVerbose("Unknown message: {0}", ComTextHelper.GetEscapedText(message));
-                    break;
-                }
+                    {
+                        this.LogVerbose("Unknown message: {0}", ComTextHelper.GetEscapedText(message));
+                        break;
+                    }
             }
         }
 
@@ -1003,6 +1003,7 @@ namespace PepperDashPluginSamsungMdcDisplay
             WarmupTimer = new CTimer(
                 o =>
                 {
+                    WarmupTimer = null;
                     _isWarmingUp = false;
 
                     IsWarmingUpFeedback.FireUpdate();
@@ -1058,6 +1059,7 @@ namespace PepperDashPluginSamsungMdcDisplay
             CooldownTimer = new CTimer(
                 o =>
                 {
+                    CooldownTimer = null;
                     _isCoolingDown = false;
                     PowerIsOnFeedback.FireUpdate();
                     IsCoolingDownFeedback.FireUpdate();
@@ -1616,7 +1618,7 @@ namespace PepperDashPluginSamsungMdcDisplay
             {
                 // Debounce for fader movements
                 _queuedVolumeLevel = level;
-                
+
                 // Restart the debounce timer - waits 500ms after last change before sending
                 if (_volumeDebounceTimer != null)
                 {
@@ -1653,7 +1655,7 @@ namespace PepperDashPluginSamsungMdcDisplay
             {
                 scaled = (int)NumericalHelpers.Scale(level, 0, 65535, _lowerLimit, _upperLimit);
             }
-            
+
             SendBytes(
                 new byte[]
                 {
@@ -1665,7 +1667,7 @@ namespace PepperDashPluginSamsungMdcDisplay
                     0x00,
                 }
             );
-            
+
             if (_isMuted)
             {
                 MuteOff();
@@ -1762,7 +1764,7 @@ namespace PepperDashPluginSamsungMdcDisplay
 
             // Always update the internal state
             _volumeLevelForSig = newVol;
-            
+
             // Only fire feedback if debounce timer is not active (i.e., not awaiting user to finish adjusting fader)
             // This prevents echo loops while still updating UI on device changes
             if (_volumeDebounceTimer == null)

--- a/src/SamsungMdc.cs
+++ b/src/SamsungMdc.cs
@@ -516,72 +516,72 @@ namespace PepperDashPluginSamsungMdcDisplay
             {
                 // General status
                 case SamsungMdcCommands.StatusControl:
+                {
+                    //UpdatePowerFB(message[2], message[5]); // "power" can be misrepresented when the display sleeps
+                    // Handle the first power on fb when waiting for it.
+                    if (_isPoweringOnIgnorePowerFb && message[6] == SamsungMdcCommands.PowerOn)
                     {
-                        //UpdatePowerFB(message[2], message[5]); // "power" can be misrepresented when the display sleeps
-                        // Handle the first power on fb when waiting for it.
-                        if (_isPoweringOnIgnorePowerFb && message[6] == SamsungMdcCommands.PowerOn)
-                        {
-                            _isPoweringOnIgnorePowerFb = false;
-                        }
-                        // Ignore general-status power off messages when powering up
-                        // if (!(_isPoweringOnIgnorePowerFb && message[6] == PowerOff))
-                        UpdatePowerFb(message[6]);
-                        UpdateVolumeFb(message[7]);
-                        UpdateMuteFb(message[8]);
-                        UpdateInputFb(message[9]);
-                        if (Debug.Level == 2)
-                        {
-                            // This check is here to prevent following string format from building unnecessarily on level 0 or 1
-                            this.LogVerbose(
-                                "StatusControl Power-'{0}d', Input-'{1}d',  Volume-'{2}d', Mute-'{3}d'",
-                                message[6],
-                                message[9],
-                                message[7],
-                                message[8]
-                            );
-                        }
-                        break;
+                        _isPoweringOnIgnorePowerFb = false;
                     }
+                    // Ignore general-status power off messages when powering up
+                    // if (!(_isPoweringOnIgnorePowerFb && message[6] == PowerOff))
+                    UpdatePowerFb(message[6]);
+                    UpdateVolumeFb(message[7]);
+                    UpdateMuteFb(message[8]);
+                    UpdateInputFb(message[9]);
+                    if (Debug.Level == 2)
+                    {
+                        // This check is here to prevent following string format from building unnecessarily on level 0 or 1
+                        this.LogVerbose(
+                            "StatusControl Power-'{0}d', Input-'{1}d',  Volume-'{2}d', Mute-'{3}d'",
+                            message[6],
+                            message[9],
+                            message[7],
+                            message[8]
+                        );
+                    }
+                    break;
+                }
                 // Power status
                 case SamsungMdcCommands.PowerControl:
-                    {
-                        this.LogVerbose("PowerControl-'{0}d'", message[6]);
-                        UpdatePowerFb(message[6]);
-                        break;
-                    }
+                {
+                    this.LogVerbose("PowerControl-'{0}d'", message[6]);
+                    UpdatePowerFb(message[6]);
+                    break;
+                }
                 // Volume level
                 case SamsungMdcCommands.VolumeControl:
+                {
+                    if (message[6] != _lastVolumeFeedbackReceived)
                     {
-                        if (message[6] != _lastVolumeFeedbackReceived)
-                        {
-                            this.LogVerbose("VolumeControl-'{0}d'", message[6]);
-                            _lastVolumeFeedbackReceived = message[6];
-                        }
-                        UpdateVolumeFb(message[6]);
-                        break;
+                        this.LogVerbose("VolumeControl-'{0}d'", message[6]);
+                        _lastVolumeFeedbackReceived = message[6];
                     }
+                    UpdateVolumeFb(message[6]);
+                    break;
+                }
                 // Volume mute status
                 case SamsungMdcCommands.MuteControl:
+                {
+                    if (message[6] != _lastMuteFeedbackReceived)
                     {
-                        if (message[6] != _lastMuteFeedbackReceived)
-                        {
-                            this.LogVerbose("MuteControl-'{0}d'", message[6]);
-                            _lastMuteFeedbackReceived = message[6];
-                        }
-                        UpdateMuteFb(message[6]);
-                        break;
+                        this.LogVerbose("MuteControl-'{0}d'", message[6]);
+                        _lastMuteFeedbackReceived = message[6];
                     }
+                    UpdateMuteFb(message[6]);
+                    break;
+                }
                 // Input status
                 case SamsungMdcCommands.InputSourceControl:
+                {
+                    if (message[6] != _lastInputFeedbackReceived)
                     {
-                        if (message[6] != _lastInputFeedbackReceived)
-                        {
-                            this.LogVerbose("InputSourceControl-'{0}d'", message[6]);
-                            _lastInputFeedbackReceived = message[6];
-                        }
-                        UpdateInputFb(message[6]);
-                        break;
+                        this.LogVerbose("InputSourceControl-'{0}d'", message[6]);
+                        _lastInputFeedbackReceived = message[6];
                     }
+                    UpdateInputFb(message[6]);
+                    break;
+                }
                 // Monitoring (Sub CMD 0x84, 2.1.D0.84 Monitoring, pdf page 228 or 244)
                 // msg[0] = Header, 0xAA
                 // msg[1] = Command, 0xFF
@@ -601,75 +601,75 @@ namespace PepperDashPluginSamsungMdcDisplay
                 // msg[n] = val-n, moduleN
                 // msg[n+1] = val-n+1, moduleN LED error data
                 case SamsungMdcCommands.LedProductFeature:
+                {
+                    this.LogVerbose(
+                        "LedProductFeature SubCmd{0} DataLen{1}",
+                        message[6],
+                        message[3]
+                    );
+
+                    if (message[6] == SamsungMdcCommands.LedSubcmdMonitoring)
                     {
                         this.LogVerbose(
-                            "LedProductFeature SubCmd{0} DataLen{1}",
+                            "LedProductFeature SubCmd{0} Temperature{1}",
                             message[6],
-                            message[3]
+                            message[9]
                         );
-
-                        if (message[6] == SamsungMdcCommands.LedSubcmdMonitoring)
-                        {
-                            this.LogVerbose(
-                                "LedProductFeature SubCmd{0} Temperature{1}",
-                                message[6],
-                                message[9]
-                            );
-                            UpdateLedTemperatureFb(message[9]);
-                        }
-                        break;
+                        UpdateLedTemperatureFb(message[9]);
                     }
+                    break;
+                }
                 // Serial number control
                 case SamsungMdcCommands.SerialNumberControl:
-                    {
-                        var serialNumber = new byte[18];
-                        Array.Copy(message, 6, serialNumber, 0, 18);
+                {
+                    var serialNumber = new byte[18];
+                    Array.Copy(message, 6, serialNumber, 0, 18);
 
-                        UpdateSerialNumber(serialNumber);
-                        break;
-                    }
+                    UpdateSerialNumber(serialNumber);
+                    break;
+                }
                 // Software version control
                 case SamsungMdcCommands.SwVersionControl:
-                    {
-                        var length = message[3];
+                {
+                    var length = message[3];
 
-                        var firmware = new byte[length];
+                    var firmware = new byte[length];
 
-                        Array.Copy(message, 6, firmware, 0, length);
+                    Array.Copy(message, 6, firmware, 0, length);
 
-                        UpdateFirmwareVersion(firmware);
-                        break;
-                    }
+                    UpdateFirmwareVersion(firmware);
+                    break;
+                }
                 // Network info
                 case SamsungMdcCommands.SystemConfiguration:
+                {
+                    var length = message[3];
+                    if (message[4] == SamsungMdcCommands.NetworkConfiguration)
                     {
-                        var length = message[3];
-                        if (message[4] == SamsungMdcCommands.NetworkConfiguration)
-                        {
-                            var ipAddressInfo = new byte[length - 1];
+                        var ipAddressInfo = new byte[length - 1];
 
-                            Array.Copy(message, 7, ipAddressInfo, 0, length - 1);
+                        Array.Copy(message, 7, ipAddressInfo, 0, length - 1);
 
-                            UpdateNetworkInfo(ipAddressInfo);
-                            break;
-                        }
-
-                        if (message[4] == SamsungMdcCommands.SystemConfigurationMacAddress)
-                        {
-                            var macInfo = new byte[length - 1];
-
-                            Array.Copy(message, 6, macInfo, 0, length - 1);
-
-                            UpdateMacAddress(macInfo);
-                        }
-
+                        UpdateNetworkInfo(ipAddressInfo);
                         break;
                     }
+
+                    if (message[4] == SamsungMdcCommands.SystemConfigurationMacAddress)
+                    {
+                        var macInfo = new byte[length - 1];
+
+                        Array.Copy(message, 6, macInfo, 0, length - 1);
+
+                        UpdateMacAddress(macInfo);
+                    }
+
+                    break;
+                }
                 default:
-                    {
-                        this.LogVerbose("Unknown message: {0}", ComTextHelper.GetEscapedText(message));
-                        break;
-                    }
+                {
+                    this.LogVerbose("Unknown message: {0}", ComTextHelper.GetEscapedText(message));
+                    break;
+                }
             }
         }
 
@@ -1618,7 +1618,7 @@ namespace PepperDashPluginSamsungMdcDisplay
             {
                 // Debounce for fader movements
                 _queuedVolumeLevel = level;
-
+                
                 // Restart the debounce timer - waits 500ms after last change before sending
                 if (_volumeDebounceTimer != null)
                 {
@@ -1655,7 +1655,7 @@ namespace PepperDashPluginSamsungMdcDisplay
             {
                 scaled = (int)NumericalHelpers.Scale(level, 0, 65535, _lowerLimit, _upperLimit);
             }
-
+            
             SendBytes(
                 new byte[]
                 {
@@ -1667,7 +1667,7 @@ namespace PepperDashPluginSamsungMdcDisplay
                     0x00,
                 }
             );
-
+            
             if (_isMuted)
             {
                 MuteOff();
@@ -1764,7 +1764,7 @@ namespace PepperDashPluginSamsungMdcDisplay
 
             // Always update the internal state
             _volumeLevelForSig = newVol;
-
+            
             // Only fire feedback if debounce timer is not active (i.e., not awaiting user to finish adjusting fader)
             // This prevents echo loops while still updating UI on device changes
             if (_volumeDebounceTimer == null)


### PR DESCRIPTION
This pull request makes small but important improvements to the `SamsungMdc` class by ensuring that timer references are properly cleared after use, which helps prevent potential issues with lingering timers.

- Timer management improvements:
  * In the `PowerOn()` method, the `WarmupTimer` reference is set to `null` after the timer completes, ensuring the timer can be garbage collected and preventing accidental reuse.
  * In the `PowerOff()` method, the `CooldownTimer` reference is set to `null` after the timer completes, for the same reasons as above.